### PR TITLE
Updated API catalog path for deprecated API

### DIFF
--- a/power-bi/dwc.m
+++ b/power-bi/dwc.m
@@ -177,7 +177,7 @@ shared SAPDWC_URL.Contents =
 getServiceURL = (product as text, host as text, selectedSource as text, space as nullable text, view as nullable text, accesstype as text) =>
     let
 
-        catalog_path_DWC = "/api/v1/dwc/catalog/assets",
+        catalog_path_DWC = "/api/v1/datasphere/consumption/catalog/assets",
 
         // use first char as "key"
         useCatalogService       = if Text.At(selectedSource,0) = "1" then true else false,


### PR DESCRIPTION
In the latest Datasphere release (2025.19) the currently used API endpoint has been deprecated.

Data Modeling－New OData Consumption API URLs
The OData consumption API URLs are modified to:
GET https://<tenant_url>/api/v1/datasphere/consumption/<request>

The existing URLs are deprecated and will be removed in a future version.
See:
[Consume Data via the OData API](https://help.sap.com/docs/PRODUCTS/d4185d7d9a634d06a5459c214792c67e/7a453609c8694b029493e7d87e0de60a.html?version=cloud&locale=en-US).
[ODATA API Documentation](https://api.sap.com/api/DatasphereCatalog/resource/SAP_Datasphere_Consumption_Catalog)