### PR TITLE
Fix OAuth ResourceAccessAuthorizationException in PowerBI connector

### DIFF
--- a/power-bi/dwc.m
+++ b/power-bi/dwc.m
@@ -436,10 +436,10 @@ TokenMethod = (code, connection) =>
                 [
                     code = code,
                     grant_type = "authorization_code",
-                    response_type = " token",
                     redirect_uri = redirect_uri
                 ])),
-                Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json", #"Authorization" = "Basic " & BasicAuth]
+                Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json", #"Authorization" = "Basic " & BasicAuth],
+                ManualCredentials = true
             ]),
         TokenList = Json.Document(Response)
     in
@@ -452,10 +452,10 @@ TokenClientCredentials = (clientId, clientSecret, tokenUrl) =>
             tokenUrl,
             [Content = Text.ToBinary(Uri.BuildQueryString(
                 [
-                    grant_type = "client_credentials",
-                    response_type = " token"
+                    grant_type = "client_credentials"
                 ])),
-                Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json", #"Authorization" = "Basic " & BasicAuth]
+                Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json", #"Authorization" = "Basic " & BasicAuth],
+                ManualCredentials = true
             ]),
         TokenList = Json.Document(Response)
     in
@@ -490,7 +490,8 @@ Refresh_DWC = (dataSourcePath, oldCredential) =>
         Response = Web.Contents(
                       connection[auth_token_url],
                       [ Content = Request,
-                        Headers = RequestHeaders ]),
+                        Headers = RequestHeaders,
+                        ManualCredentials = true ]),
 
         NewTokenList = Json.Document(Response)
     in


### PR DESCRIPTION
Add ManualCredentials = true to all Web.Contents calls targeting the token endpoint, preventing the Mashup engine from attempting credential resolution on a URL outside the data source path. 

Also remove the non-standard response_type parameter from token exchange requests.

[meta:ai-assisted]